### PR TITLE
Preparando entorno / guias para ocupar gitflow

### DIFF
--- a/GuiaAplicarGitFlow.md
+++ b/GuiaAplicarGitFlow.md
@@ -1,0 +1,87 @@
+# Proyecto Spring Boot para Curso DevOps
+
+## Descripción del Proyecto
+
+Este es un proyecto desarrollado en Spring Boot Java como parte de un curso de DevOps. La aplicación implementa un CRUD (Create, Read, Update, Delete) para la gestión de eventos y salones, e integra diversas herramientas y prácticas propias de DevOps:
+
+- Jenkins
+- Nexus
+- SonarQube
+- Selenium
+
+Además, la aplicación cuenta con Spring Security para la gestión de autenticación y autorización.
+
+## Endpoints Públicos
+
+Los siguientes endpoints están disponibles sin necesidad de autenticación:
+
+- `/api/salones`: Consulta de salones
+- `/api/eventos`: Consulta de eventos
+
+El resto de las rutas requieren que los usuarios se registren y autentiquen. Sin autenticación, solo se mostrará la pantalla inicial de login.
+
+## Estructura del Repositorio
+
+El proyecto sigue el modelo de Git Flow para la gestión de ramas:
+
+- `main`: Contiene el código listo para producción. Protegida contra cambios directos.
+- `develop`: Rama de desarrollo continuo donde se integran las nuevas características.
+
+## Flujo de Trabajo con Git Flow
+
+### 1. Desarrollo de Nuevas Funcionalidades
+
+```bash
+# Iniciar una nueva funcionalidad
+git flow feature start nombre-feature
+
+# Desarrollar y hacer commits
+
+# Finalizar la funcionalidad
+git flow feature finish nombre-feature
+
+# Subir cambios a develop
+git push origin develop
+```
+
+### 2. Preparación de una Nueva Versión
+
+```bash
+# Iniciar una nueva release
+git flow release start nombre-release
+
+# Realizar ajustes finales
+
+# Finalizar la release
+git flow release finish nombre-release
+
+# Subir cambios y tags
+git push origin main
+git push origin develop
+git push --tags
+```
+
+### 3. Corrección de Errores en Producción
+
+```bash
+# Iniciar un hotfix
+git flow hotfix start nombre-hotfix
+
+# Aplicar la corrección
+
+# Finalizar el hotfix
+git flow hotfix finish nombre-hotfix
+
+# Subir cambios y tags
+git push origin main
+git push origin develop
+git push --tags
+```
+
+## Resumen del Flujo de Trabajo
+
+1. Desarrollo continuo en `develop` a través de ramas de feature.
+2. Preparación de versiones en ramas de release antes de fusionarlas en `main`.
+3. Corrección rápida de errores críticos en ramas de hotfix directamente desde `main`.
+
+Este flujo de trabajo permite mantener el proyecto organizado y asegura que la rama `main` siempre contenga código listo para producción, mientras que `develop` es el espacio para la integración continua de nuevas funcionalidades.

--- a/PreparacionGitFlow.md
+++ b/PreparacionGitFlow.md
@@ -1,0 +1,84 @@
+Esto es un proyecto en spring boot java, que lo estoy ocupando para desarrollar un curso de DevOps, este proyecto ocupa jenkins, nexxus, sonar, selenium, en fin, todo lo que ocupa una app que se integra con los principios DevOps, esta es una app mantenedor de eventos y salones (es un crud) a su vez tiene spring security, que las unicas direcciones libres son para consultar la api de salones, y eventos : 
+/api/salones
+/api/eventos
+
+el resto de direcciones requiere que se registren, y logeen, si no solo veran la pantalla inicial de login . 
+
+1. Revisar las ramas actuales
+Antes de empezar a usar Git Flow plenamente, revisa las ramas existentes y decide si alguna de ellas necesita ser integrada en develop o si pueden ser eliminadas. Asegúrate de que todos los cambios importantes estén en develop y que main contenga un estado estable del proyecto.
+
+2. Trabajar en nuevas funcionalidades (Feature branches)
+Para agregar una nueva funcionalidad, sigue este flujo:
+
+Crear una nueva rama de característica: Utiliza Git Flow para crear una rama de característica a partir de develop:
+
+git flow feature start nombre-feature
+Esto creará y te moverá a una nueva rama llamada feature/nombre-feature.
+
+Desarrollar en la rama de característica: Realiza tus cambios en la rama feature/nombre-feature. Puedes hacer commits y push a esta rama a medida que trabajas.
+
+Finalizar la rama de característica: Una vez que hayas terminado de desarrollar la funcionalidad, finaliza la rama y mézclala en develop:
+
+git flow feature finish nombre-feature
+Esto hará un merge de la rama de característica en develop y eliminará la rama feature/nombre-feature localmente.
+
+3. Crear una versión candidata (Release branches)
+Cuando estés listo para preparar una nueva versión de la aplicación:
+
+Crear una rama de lanzamiento:
+
+
+git flow release start nombre-release
+Esto crea una rama release/nombre-release a partir de develop.
+
+Realizar ajustes finales: En esta rama, puedes hacer ajustes finales, como actualizar la documentación o corregir bugs menores.
+
+Finalizar la rama de lanzamiento: Cuando todo esté listo para el lanzamiento:
+
+
+git flow release finish nombre-release
+Esto fusionará la rama en main (donde se genera el tag de versión) y en develop (para mantenerlo actualizado). Luego, eliminará la rama release.
+
+Push a main y develop: No olvides hacer push de los cambios en main y develop después de finalizar la rama de release:
+
+
+git push origin main
+git push origin develop
+git push --tags
+4. Manejo de Hotfixes
+Para corregir un bug en producción sin interrumpir el desarrollo en develop:
+
+Crear una rama de hotfix:
+
+
+git flow hotfix start nombre-hotfix
+Esto crea una rama hotfix/nombre-hotfix a partir de main.
+
+Arreglar el bug y finalizar el hotfix: Después de solucionar el problema, finaliza la rama:
+
+
+git flow hotfix finish nombre-hotfix
+Esto fusionará los cambios en main y develop, aplicando el hotfix a ambas ramas y eliminando la rama hotfix.
+
+5. Revisión de ramas antiguas
+Si tienes ramas antiguas que no encajan en la estructura de Git Flow, considera integrarlas manualmente en develop o main, o eliminarlas si ya no son necesarias:
+
+Integrar ramas:
+
+
+git checkout develop
+git merge nombre-rama
+git branch -d nombre-rama
+Eliminar ramas que no son necesarias:
+
+
+git branch -d nombre-rama
+git push origin --delete nombre-rama
+6. Configurar políticas de pull requests
+Para asegurarte de que no se hagan cambios directamente en main, configura en tu repositorio remoto políticas que requieran pull requests para fusionar cambios en main.
+
+Resumen
+Usa ramas feature para desarrollar nuevas funcionalidades.
+Usa ramas release para preparar versiones.
+Usa ramas hotfix para corregir bugs en producción.
+Asegúrate de hacer merge de las ramas correctamente usando Git Flow y no hagas push directo a main sin una revisión adecuada.


### PR DESCRIPTION
GitFlow ya implementado, se trabajará con esta metodologia de ahora en adelante. Para evitar hacer push a la rama main, si no que todo pase por un PR antes, y se pueda revisar . Garantizando que el entorno de producción siempre este correcto, y solo se ocupe la rama develop y features.